### PR TITLE
[fix] Add missing dependencies to workflow pip installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pyproject_hooks packaging
           pip install --no-deps build twine
           
       - name: Build package

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Build package
       run: |
+        pip install pyproject_hooks packaging
         pip install --no-deps build twine
         python -m build
         


### PR DESCRIPTION
## Summary
- Added missing dependencies `pyproject_hooks` and `packaging` to the workflow pip installs
- Both the update-homebrew.yml and release.yml workflows were failing because the `--no-deps` flag prevents installing required dependencies
- This change should allow workflows to install the necessary dependencies and run successfully

## Test plan
- Merge this PR and then create a new tag/release to verify workflows run successfully
- Check that the GitHub release is created and the Homebrew formula is updated

🤖 Generated with [Claude Code](https://claude.ai/code)