### PR TITLE
[fix] Update GitHub release action to use softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,23 +28,10 @@ jobs:
         run: |
           python -m build
           
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          files: ./dist/v2a-${{ github.ref_name }}.tar.gz
+          name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
-          
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/v2a-${{ github.ref_name }}.tar.gz
-          asset_name: v2a-${{ github.ref_name }}.tar.gz
-          asset_content_type: application/gzip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "v2a"
-version = "1.0.4"
+version = "1.0.5"
 description = "Video to Audio Converter"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/v2a/__init__.py
+++ b/v2a/__init__.py
@@ -1,3 +1,3 @@
 """Video to Audio Converter package."""
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"


### PR DESCRIPTION
## Summary
- Updated the GitHub release action to use `softprops/action-gh-release@v2` instead of the deprecated `actions/create-release@v1`
- The previous action was showing 'Resource not accessible by integration' errors
- Simplified the release workflow by combining release creation and asset upload into a single step

## Test plan
- Merge this PR and create a new tag to verify the release workflow functions correctly
- Check that both the GitHub release is created and assets are uploaded successfully

🤖 Generated with [Claude Code](https://claude.ai/code)