### PR TITLE
[fix] Add GitHub Actions permissions and fix release asset path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'  # Push events to tags matching v*, i.e., v1.0.0, v20.15.10
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Create Release
@@ -27,11 +30,12 @@ jobs:
       - name: Build package
         run: |
           python -m build
+          ls -la dist/  # Debug: Check what files are actually built
           
       - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
-          files: ./dist/v2a-${{ github.ref_name }}.tar.gz
+          files: ./dist/*.tar.gz  # Use a more flexible pattern to match the tarball
           name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -7,6 +7,9 @@ on:
       - 'pyproject.toml'  # Only run when version might have changed
       - 'v2a/**'          # Or when core package files change
 
+permissions:
+  contents: read
+
 jobs:
   update-homebrew:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "v2a"
-version = "1.0.5"
+version = "1.0.6"
 description = "Video to Audio Converter"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/v2a/__init__.py
+++ b/v2a/__init__.py
@@ -1,3 +1,3 @@
 """Video to Audio Converter package."""
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"


### PR DESCRIPTION
## Summary
- Added explicit `permissions: contents: write` to the release workflow to allow creating releases
- Added explicit `permissions: contents: read` to the Homebrew update workflow
- Fixed the release asset path to use a more flexible pattern (./dist/*.tar.gz)
- Added debugging to show the actual files that are built 

## Test plan
- Merge this PR and create a new tag to verify the release workflow functions correctly
- Check that both the GitHub release is created and assets are uploaded successfully

🤖 Generated with [Claude Code](https://claude.ai/code)