### PR TITLE
[fix] Fix Homebrew formula update check for new files

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -87,11 +87,16 @@ jobs:
       id: check_changes
       run: |
         cd homebrew-tools
-        if git diff --exit-code ${{ env.FORMULA_NAME }}.rb; then
-          echo "No changes to commit"
-          echo "CHANGES_EXIST=false" >> $GITHUB_ENV
+        if [ -f ${{ env.FORMULA_NAME }}.rb ]; then
+          if git diff --exit-code ${{ env.FORMULA_NAME }}.rb; then
+            echo "No changes to commit for existing file"
+            echo "CHANGES_EXIST=false" >> $GITHUB_ENV
+          else
+            echo "Changes to commit for existing file"
+            echo "CHANGES_EXIST=true" >> $GITHUB_ENV
+          fi
         else
-          echo "Changes to commit"
+          echo "New formula file created"
           echo "CHANGES_EXIST=true" >> $GITHUB_ENV
         fi
 


### PR DESCRIPTION
## Summary
- Fixed the Homebrew formula update workflow to properly handle new formula files
- The previous implementation was checking for changes with `git diff` which doesn't detect new files
- Added a check to see if the formula file exists first and set `CHANGES_EXIST=true` for new files

## Test plan
- Merge this PR and create a new version to trigger the workflow
- Verify that the v2a formula is created in the homebrew-tools repository

🤖 Generated with [Claude Code](https://claude.ai/code)