### PR TITLE
[fix] Fix Homebrew formula git status check

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -87,16 +87,20 @@ jobs:
       id: check_changes
       run: |
         cd homebrew-tools
-        if [ -f ${{ env.FORMULA_NAME }}.rb ]; then
+        
+        # Check if the file is tracked by git
+        if git ls-files --error-unmatch ${{ env.FORMULA_NAME }}.rb 2>/dev/null; then
+          # File exists and is tracked by git
           if git diff --exit-code ${{ env.FORMULA_NAME }}.rb; then
-            echo "No changes to commit for existing file"
+            echo "No changes to commit for existing tracked file"
             echo "CHANGES_EXIST=false" >> $GITHUB_ENV
           else
-            echo "Changes to commit for existing file"
+            echo "Changes to commit for existing tracked file"
             echo "CHANGES_EXIST=true" >> $GITHUB_ENV
           fi
         else
-          echo "New formula file created"
+          # File either doesn't exist or is not tracked by git
+          echo "New formula file or untracked file - Will add to git"
           echo "CHANGES_EXIST=true" >> $GITHUB_ENV
         fi
 


### PR DESCRIPTION
## Summary
- Fixed the Homebrew formula update workflow git status check
- The previous implementation was checking if the file exists but not if it's tracked by git
- The file was being created but not being committed because git status check was failing
- Added a check using `git ls-files` to properly detect untracked files

## Test plan
- Merge this PR and create a new version to trigger the workflow
- Verify that the v2a formula is created in the homebrew-tools repository

🤖 Generated with [Claude Code](https://claude.ai/code)