### PR TITLE
[fix] Fix Homebrew formula SHA256 calculation

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -45,7 +45,11 @@ jobs:
     - name: Calculate SHA256
       id: sha256
       run: |
-        SHA256=$(sha256sum dist/v2a-${{ env.VERSION }}.tar.gz | cut -d' ' -f1)
+        # Download the tarball from GitHub to calculate the correct SHA256
+        TARBALL_URL="https://github.com/cajias/v2a/archive/v${{ env.VERSION }}.tar.gz"
+        echo "Downloading tarball from: $TARBALL_URL"
+        curl -sL -o /tmp/v2a-${{ env.VERSION }}.tar.gz "$TARBALL_URL"
+        SHA256=$(sha256sum /tmp/v2a-${{ env.VERSION }}.tar.gz | cut -d' ' -f1)
         echo "SHA256=$SHA256" >> $GITHUB_ENV
         echo "SHA256: $SHA256"
 


### PR DESCRIPTION
## Summary
- Fixed the SHA256 calculation for Homebrew formula
- Previous implementation was calculating SHA256 from the locally built package, which differs from GitHub's tarball
- The SHA256 in the formula needs to match the actual GitHub tarball
- Modified the workflow to download the tarball from GitHub and calculate the correct SHA256

## Test plan
- Merge this PR and create a new version to trigger the workflow
- Verify that the v2a formula is created in the homebrew-tools repository
- Verify that the formula can be installed with `brew install cajias/tools/v2a`

🤖 Generated with [Claude Code](https://claude.ai/code)