### PR TITLE
[fix] Fix Homebrew formula Python installation

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -77,8 +77,9 @@ jobs:
           depends_on "python@3.9"
 
           def install
-            virtualenv_create(libexec, "python3.9")
-            virtualenv_install_with_resources
+            venv = virtualenv_create(libexec, "python3.9")
+            venv.pip_install buildpath
+            bin.install_symlink Dir["\#{libexec}/bin/*"]
           end
 
           test do


### PR DESCRIPTION
## Summary
- Fixed the Homebrew formula Python installation method
- Previous implementation was using `virtualenv_install_with_resources` which is not defined in Homebrew
- Updated to use proper Homebrew Python formula pattern with `venv.pip_install buildpath`
- Added proper symlink creation for the installed command

## Test plan
- Merge this PR and create a new version to trigger the workflow
- Verify that the v2a formula is updated in the homebrew-tools repository
- Verify that the formula can be installed with `brew install cajias/tools/v2a`

🤖 Generated with [Claude Code](https://claude.ai/code)