### PR TITLE
[fix] Fix Homebrew formula with proper Python module requirement

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -67,6 +67,8 @@ jobs:
         # Create or update the formula
         cat > ${{ env.FORMULA_NAME }}.rb << EOL
         class V2a < Formula
+          include Language::Python::Virtualenv
+
           desc "Video to Audio Converter"
           homepage "https://github.com/cajias/v2a"
           url "https://github.com/cajias/v2a/archive/v${{ env.VERSION }}.tar.gz"
@@ -77,9 +79,7 @@ jobs:
           depends_on "python@3.9"
 
           def install
-            venv = virtualenv_create(libexec, "python3.9")
-            venv.pip_install buildpath
-            bin.install_symlink Dir["\#{libexec}/bin/*"]
+            virtualenv_install_with_resources
           end
 
           test do


### PR DESCRIPTION
## Summary
- Fixed the Homebrew formula by adding the proper Python module requirement
- Added `include Language::Python::Virtualenv` to the formula
- Simplified the formula by using just `virtualenv_install_with_resources`

## Test plan
- Merge this PR and create a new version to trigger the workflow
- Verify that the v2a formula is updated in the homebrew-tools repository
- Verify that the formula can be installed with `brew install cajias/tools/v2a`

🤖 Generated with [Claude Code](https://claude.ai/code)