### PR TITLE
[chore] Bump version to 1.0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "v2a"
-version = "1.0.11"
+version = "1.0.12"
 description = "Video to Audio Converter"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/v2a/__init__.py
+++ b/v2a/__init__.py
@@ -1,3 +1,3 @@
 """Video to Audio Converter package."""
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"


### PR DESCRIPTION
## Summary
- Bumped version from 1.0.11 to 1.0.12
- Testing final Homebrew formula fix

## Test plan
- Verify that the GitHub release is created automatically
- Verify that the Homebrew formula is updated in cajias/homebrew-tools
- Verify that the formula can be installed with `brew install cajias/tools/v2a`

🤖 Generated with [Claude Code](https://claude.ai/code)